### PR TITLE
Fix https://github.com/fntsrlike/slack-irc-plugin/issues/3 problem

### DIFF
--- a/lib/slack2irc.js
+++ b/lib/slack2irc.js
@@ -69,7 +69,7 @@ Slack2IRC.prototype._sentMessage = function(payload) {
   name = '<' + name + '>: ';
   message = name + message.replace(/\n/g, '\n' + name);
 
-  this.slackbot.speak(channel, message);
+  this.ircBot.speak(channel, message);
 };
 
 Slack2IRC.prototype._decodeMessage = function(text) {


### PR DESCRIPTION
There has no `slackbot` in slack2irc.
To send message to IRC, we have to use `ircBot`.
