### PR TITLE
Catch /me on irc and render as italics font on Slack

### DIFF
--- a/lib/irc-to-slack.js
+++ b/lib/irc-to-slack.js
@@ -14,7 +14,11 @@ var IrcToSlack = function(config) {
   return this;
 };
 
-IrcToSlack.prototype._prepareMessage = function(message) {
+IrcToSlack.prototype._prepareMessage = function(message, type) {
+  if (type === 'action') {
+      // render the text of /me on irc as italics on Slack
+      message = '_' + message + '_';
+  }
   return IrcMsgEncoder(message)
     .setChanelMap(this.ircBot.config.channels)
     .setUserMap(this.nameMap.getIrcWhoIsMap())
@@ -22,7 +26,7 @@ IrcToSlack.prototype._prepareMessage = function(message) {
     .autoMention().encodeMention().encodeAmpersand().toString();
 };
 
-IrcToSlack.prototype._sentToSlack = function(from, to, message) {
+IrcToSlack.prototype._sentToSlack = function(type, from, to, message) {
   var
   username = from,
   avatar = this.config.iconUrl,
@@ -42,7 +46,7 @@ IrcToSlack.prototype._sentToSlack = function(from, to, message) {
   if (!message.match(/.+url.*:\ \[.+\]/)) {
     this.slackBot.send('chat.postMessage', {
       channel: this.config.channels[to],
-      text: this._prepareMessage(message),
+      text: this._prepareMessage(message, type),
       username: username + ' (irc)',
       icon_url: avatar,
       icon_emoji: this.config.iconEmoji
@@ -66,7 +70,8 @@ IrcToSlack.prototype.setNameMap = function(nameMap) {
 };
 
 IrcToSlack.prototype.listen = function() {
-  this.ircBot.addListener('message', this._sentToSlack.bind(this));
+  this.ircBot.addListener('message', this._sentToSlack.bind(this, 'message'));
+  this.ircBot.addListener('action', this._sentToSlack.bind(this, 'action'));
 };
 
 


### PR DESCRIPTION
Because there's no Slack API for `/me`
and send '/me' directly to Slack do not work
but the `/me` on Slack is very simillar to italics effect
so just let the message render as a italics font on Slack
